### PR TITLE
fix(screens): disable pointer-events on src

### DIFF
--- a/utils/screens/index.html
+++ b/utils/screens/index.html
@@ -444,6 +444,7 @@ ready(function() {
 		position: absolute;
 		background-color: rgba(128,128,128,0.75);
 		display: grid;
+		pointer-events: none;
 	}
 	.src.misfit {
 		background-color: rgba(255,0,0,0.75);


### PR DESCRIPTION
Since the slight redesign, it's become a lot easier to tick 'Crop Overscan' and then have the src overlay grow to the point of covering the controls, frustrating the ability to then disable this again.

![image](https://github.com/user-attachments/assets/cbc916d4-a740-4fa2-bb77-374c25fb71e2)

This PR adds `pointer-events: none;` to the CSS for `.src`, allowing click events to pass through the overlay, ensuring the user can always interact with the underlying controls and disable 'Crop Overscan' or otherwise select another console in these events, without needing to reopen the page to reset everything (and potentially lose any Custom screen size entered)