### PR TITLE
Add Ayaneo line of Android devices

### DIFF
--- a/utils/screens/index.html
+++ b/utils/screens/index.html
@@ -536,6 +536,7 @@ ready(function() {
 			<optgroup label="3:2">
 				<option>RS-90      (240x160 2.0")</option>
 				<option>RG351      (480x320 3.5")</option>
+				<option>Ayaneo Pocket Micro (960x640 3.5")</option>
 				<option>KT R1      (1620x1080 4.5")</option>
 			</optgroup>
 			<optgroup label="4:3">
@@ -565,9 +566,12 @@ ready(function() {
 				<option>RG503      (960x544 5.0")</option>
 				<option>RG556      (1920x1080 5.48")</option>
 				<option>WIN600     (1280x720 5.94")</option>
+				<option>Ayaneo Pocket S (2560x1440 6")</option>
+				<option>Ayaneo Pocket EVO (1920x1080 7")</option>
 			</optgroup>
 			<optgroup label="Other">
 				<option>Analogue Pocket (1600x1440 3.5")</option>
+				<option>Ayaneo Pocket DMG (1240x1080 3.92")</option>
 				<option>Steam Deck (1280x800 7")</option>
 			</optgroup>
 		</select>


### PR DESCRIPTION
Kept the Ayaneo name as maybe the model names alone might not be recognizable enough. 