### PR TITLE
add multiple consoles/screens

### DIFF
--- a/utils/screens/index.html
+++ b/utils/screens/index.html
@@ -534,6 +534,11 @@ ready(function() {
 				<option>Nintendo DS ◫    (512x192)</option>
 				<option>Nintendo DS ⊟    (256x384)</option>
 				<option>PSP              (480x272)</option>
+				<option>Nintendo 3DS □, top    (400x240)</option>
+				<option>Nintendo 3DS □, bottom (320x240)</option>
+				<option>Nintendo 3DS ◫   (720x240)</option>
+				<option>Nintendo 3DS ⊟   (400x480)</option>
+				<option>Nintendo Switch, handheld (1280x720)</option>
 			</optgroup>
 			<optgroup label="Home Consoles">
 				<option>Nintendo         (256x240)</option>
@@ -542,6 +547,7 @@ ready(function() {
 				<option>PlayStation      (320x240)</option>
 				<option>Nintendo 64      (320x240)</option>
 				<option>Dreamcast        (640x480)</option>
+				<option>Nintendo Switch, docked (1920x1080)</option>
 			</optgroup>
 			<optgroup label="Other">
 				<option>PICO-8           (128x128)</option>
@@ -571,11 +577,13 @@ ready(function() {
 				<option>RG34XX     (720x480 3.4")</option>
 				<option>RG351      (480x320 3.5")</option>
 				<option>Ayaneo Pocket Micro (960x640 3.5")</option>
+				<option>MagicX One 35 (640x960 3.5")</option>
 				<option>KT R1      (1620x1080 4.5")</option>
 			</optgroup>
 			<optgroup label="4:3">
 				<option>Trimui Model S (320x240 2.0")</option>
 				<option>Trimui Smart   (320x240 2.4")</option>
+				<option>GKD Pixel II   (640x480 2.4")</option>
 				<option>RG280M     (320x240 2.8")</option>
 				<option>Miyoo Mini (640x480 2.8")</option>
 				<option>Miyoo Mini (v4) (752x560 2.8")</option>
@@ -587,6 +595,7 @@ ready(function() {
 				<option>RPMini     (1280x960 3.7")</option>
 				<option>RG405M     (640x480 4.0")</option>
 				<option>RG406V     (960x720 4.0")</option>
+				<option>RG477M     (1280x960 4.7")</option>
 			</optgroup>
 			<optgroup label="3:5">
 				<option>MagicX Zero 40 (480x800 4.0")</option>


### PR DESCRIPTION
consoles:
+3ds (single, top)
+3ds (single, bottom)
+3ds (side-by-side)
+3ds (stacked)
+switch (handheld)
+switch (docked)
screens:
+magicx one 35 (technically the same resolution as the ayaneo pocket micro; flipped dimensions for tate/ds mode)
+gkd pixel ii
+rg477m/477v/476h/slide